### PR TITLE
Dockerfile & Changed from 127.0.0.1(local) to 0.0.0.0(public)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+### Build container
+FROM rust:latest as builder
+WORKDIR /usr/src/myapp
+COPY . .
+RUN cargo install --path .
+### Runtime container
+FROM debian:buster-slim
+COPY ./users.csv .
+RUN apt-get update && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/merino /usr/local/bin/merino
+# CMD ["merino", "--users", "users.csv"] # with auth defined in users.csv
+CMD ["merino", "--no-auth"] # no auth

--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ merino --users users.csv
 merino --help 
 ```
 
+### Docker
+# build
+`docker build -t rust-merino-socks5proxy:latest .`
+# run detached; there is no way to exit once running unless you kill the shell
+`docker run -d --name rm-s5 rust-merino-socks5proxy:latest merino --no-auth`
+# get logs
+`
+                      _
+  _ __ ___   ___ _ __(_)_ __   ___
+ | '_ ` _ \ / _ \ '__| | '_ \ / _ \
+ | | | | | |  __/ |  | | | | | (_) |
+ |_| |_| |_|\___|_|  |_|_| |_|\___/
+
+ A SOCKS5 Proxy server written in Rust
+
+ 2021-12-10T07:43:10.253 INFO  merino > Listening on 0.0.0.0:1080
+ 2021-12-10T07:43:10.253 INFO  merino > Serving Connections...`
+
+# get shell
+`docker exec -it rm-s5 bash`
+
+
 # 🚥 Roadmap
 
 - [x] IPV6 Support

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ struct Opt {
     /// Set port to listen on
     port: u16,
 
-    #[structopt(short = "i", long = "ip", default_value = "127.0.0.1")]
+    #[structopt(short = "i", long = "ip", default_value = "0.0.0.0")]
     /// Set ip to listen on
     ip: String,
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,7 +3,7 @@ use merino::*;
 #[tokio::test]
 /// Can we crate a new `Merino` instance
 async fn merino_contructor() {
-    assert!(Merino::new(1080, "127.0.0.1", Vec::new(), Vec::new())
+    assert!(Merino::new(1080, "0.0.0.0", Vec::new(), Vec::new())
         .await
         .is_ok())
 }


### PR DESCRIPTION
# build
`docker build -t rust-merino-socks5proxy:latest .`
# run detached; there is no way to exit once running unless you kill the shell
`docker run -d --name rm-s5 rust-merino-socks5proxy:latest merino --no-auth`
# get logs
`docker logs rm-s5`
```
A SOCKS5 Proxy server written in Rust

 2021-12-10T07:43:10.253 INFO  merino > Listening on 0.0.0.0:1080
 2021-12-10T07:43:10.253 INFO  merino > Serving Connections...
```

# get shell
`docker exec -it rm-s5 bash`